### PR TITLE
clarify users and add sudo to oneliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ To install on Windows, you will have to:
 # Zero Touch Deployment
 
 ```console
-wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | bash
+wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | sudo bash
 ```
 
-This approach assumes that you have a empty Ubuntu 20.04.
+This approach assumes that:
+* You have a empty Ubuntu 20.04.
+* You don't execute the above command as the root user but create a new user and then execute the Zero Touch deploy command: 
+* `sudo adduser USER && sudo usermod -aG sudo USER && su USER && cd ~` (Change all USER occurances to your liking, or not)
 
 The script will install and configure all FreeTAKHub components.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ To install on Windows, you will have to:
 # Zero Touch Deployment
 
 ```console
-wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | sudo bash
+wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | bash
 ```
 
 This approach assumes that:
 * You have a empty Ubuntu 20.04.
 * You don't execute the above command as the root user but create a new user and then execute the Zero Touch deploy command: 
-* `sudo adduser USER && sudo usermod -aG sudo USER && su USER && cd ~` (Change all USER occurances to your liking, or not)
+* `sudo adduser USER && sudo usermod -aG sudo USER && su USER` and then `cd ~` (Change all USER occurances to your liking, or not)
 
 The script will install and configure all FreeTAKHub components.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation
 ```
 
 This approach assumes that:
-* You have a empty Ubuntu 20.04.
-* You don't execute the above command as the root user but create a new user and then execute the Zero Touch deploy command: 
+* You have a clean, freshly installed Ubuntu 20.04.
+* You don't execute the above command as the root user but create a new user first and then execute the above listed Zero Touch deploy command
 * `sudo adduser USER && sudo usermod -aG sudo USER && su USER` and then `cd ~` (Change all USER occurances to your liking, or not)
 
 The script will install and configure all FreeTAKHub components.


### PR DESCRIPTION
I think we need to use sudo in the one liner instead of just bash. 
It seems it doesn't really like running as root (LXC unprivileged container on my end so i can use root, security wise) but rather as a user with sudo permissions. The one liner does not reflect that or explains it.

Proposed: `wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | sudo bash`

Instead of: `wget -qO - https://raw.githubusercontent.com/FreeTAKTeam/FreeTAKHub-Installation/main/scripts/easy_install.sh | bash`