### PR TITLE
Vagrantfile and Videochecker

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   $script = <<-SCRIPT
-  echo Updating APT Pakcages...
-  sudo apt update && sudo apt upgrade
+  echo Updating APT Packages...
+  sudo apt update -y && sudo apt upgrade -y
   SCRIPT
 
   config.vm.provision "shell", inline: $script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,13 +6,20 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = ENV["IMAGE_DISTRO"]
-  config.vm.hostname = ENV["VAGRANTBOX"] + ".box"
-
+  config.vm.hostname = ENV["VAGRANTBOX"]
+  config.vm.boot_timeout = 1800 #30 minutes
   config.vm.provider :virtualbox do |v|
     v.memory = 4096
     v.cpus = 2
   end
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  $script = <<-SCRIPT
+  echo Updating APT Pakcages...
+  sudo apt update && sudo apt upgrade
+  SCRIPT
+
+  config.vm.provision "shell", inline: $script
 
 end

--- a/roles/nodered/templates/videochecker.json.j2
+++ b/roles/nodered/templates/videochecker.json.j2
@@ -19,6 +19,9 @@
     "persist": false,
     "proxy": "",
     "authType": "bearer",
+    "credentials": {
+        "password": "token"
+    },
     "x": 970,
     "y": 240,
     "wires": [

--- a/roles/nodered/templates/videochecker.json.j2
+++ b/roles/nodered/templates/videochecker.json.j2
@@ -14,7 +14,7 @@
     "method": "POST",
     "ret": "txt",
     "paytoqs": "ignore",
-    "url": "http://{{ videoserver_public_ipv4 }}:9997/ManageVideoStream/postVideoStream",
+    "url": "http://{{ videoserver_public_ipv4 }}:19023/ManageVideoStream/postVideoStream",
     "tls": "",
     "persist": false,
     "proxy": "",


### PR DESCRIPTION
Added the default bearer token to the Videochecker flow. I would like to improve default credentials from static creds to dynamically generated with output at the end of the installer.

Also added some bits to the Vagrantfile to provision the box fully updated.

Pushed on Saturday night because I forgot to push when I added the token on Tuesday.