### PR TITLE
Fix name change of rtsp-simple-server to mediamtx

### DIFF
--- a/roles/videoserver/defaults/main.yml
+++ b/roles/videoserver/defaults/main.yml
@@ -1,15 +1,17 @@
 ---
 videoserver_ipv4: 0.0.0.0
 
-videoserver_api_url: https://api.github.com/repos/aler9/rtsp-simple-server/releases/latest
-videoserver_package: rtsp-simple-server.tar.gz
-videoserver_executable: rtsp-simple-server
-videoserver_config_file: rtsp-simple-server.yml
+videoserver_api_url: https://api.github.com/repos/aler9/mediamtx/releases/latest
+videoserver_package: mediamtx.gz
+videoserver_executable: mediamtx
+videoserver_config_file: mediamtx.yml
 
-videoserver_service_name: rtsp-simple-server
+videoserver_service_name: mediamtx
 
 # Set initial service state. Recommended values: `started` or `stopped`.
 videoserver_state: started
 
 # Enable service.
 videoserver_enabled: true
+
+


### PR DESCRIPTION
There is information that rtsp-simple-server, now known as mediamtx will be moved to https://github.com/bluenviron.


> Important announcement

> rtsp-simple-server is being rebranded as MediaMTX. The reason is pretty obvious: this project started as a RTSP server but has evolved into a much more versatile media server (i like to call it a "media broker", a message broker for media streams), that is not tied to the RTSP protocol anymore. Nothing will change regarding license, features and backward compatibility.

>Furthermore, my main open source projects are being transferred to the [bluenviron organization](https://github.com/bluenviron), in order to allow the community to maintain and evolve the code regardless of my personal availability.

>In the next months, the repository name and the Docker image name will be changed accordingly.
