### PR TITLE
Refactor ZT to install latest version of FTS by default. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ ansible.cfg
 /.vagrant/machines/default/digital_ocean/vagrant_cwd
 /.vagrant/rgloader/loader.rb
 /.vagrant/*
+/.byebug_history
+/docs/DEV.md

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -39,7 +39,7 @@ PY3_VER_STABLE="3.11"
 
 STABLE_FTS_VERSION="2.0.69"
 LEGACY_FTS_VERSION="1.9.9.6"
-LATEST_FTS_VERSION=$(curl -s https://pypi.org/pypi/FreeTAKServer/json | jq -r .info.version)
+LATEST_FTS_VERSION=$(curl -s https://pypi.org/pypi/FreeTAKServer/json | python3 -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
 
 DRY_RUN=0
 

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -39,7 +39,7 @@ PY3_VER_STABLE="3.11"
 
 STABLE_FTS_VERSION="2.0.69"
 LEGACY_FTS_VERSION="1.9.9.6"
-LATEST_FTS_VERSION=${curl -s https://pypi.org/pypi/FreeTAKServer/json | jq -r .info.version}
+LATEST_FTS_VERSION=$(curl -s https://pypi.org/pypi/FreeTAKServer/json | jq -r .info.version)
 
 DRY_RUN=0
 

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -31,14 +31,15 @@ LEGACY_OS_VER_REQD="20.04"
 LEGACY_CODENAME_REQD="focal"
 
 # the specific versions will be set later based on INSTALL_TYPE
-DEFAULT_INSTALL_TYPE="stable"
+DEFAULT_INSTALL_TYPE="latest"
 INSTALL_TYPE="${INSTALL_TYPE:-$DEFAULT_INSTALL_TYPE}"
 
 PY3_VER_LEGACY="3.8"
 PY3_VER_STABLE="3.11"
 
-STABLE_FTS_VERSION="2.0.66"
+STABLE_FTS_VERSION="2.0.69"
 LEGACY_FTS_VERSION="1.9.9.6"
+LATEST_FTS_VERSION=${curl -s https://pypi.org/pypi/FreeTAKServer/json | jq -r .info.version}
 
 DRY_RUN=0
 
@@ -242,6 +243,14 @@ function parse_params() {
 ###############################################################################
 function set_versions() {
   case $INSTALL_TYPE in
+    latest)
+      export PY3_VER=$PY3_VER_STABLE
+      export FTS_VERSION=$LATEST_FTS_VERSION
+      export CFG_RPATH="core/configuration"
+      export OS_REQD=$STABLE_OS_REQD
+      export OS_VER_REQD=$STABLE_OS_VER_REQD
+      export CODENAME=$STABLE_CODENAME_REQD
+      ;;
     legacy)
       export PY3_VER=$PY3_VER_LEGACY
       export FTS_VERSION=$LEGACY_FTS_VERSION

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -370,6 +370,7 @@ function check_os() {
     echo "FreeTAKServer has only been tested on ${GREEN}${OS_REQD} ${OS_VER_REQD}${NOFORMAT}."
     echo -e "This machine is currently running: ${YELLOW}${OS} ${VER}${NOFORMAT}"
     echo "Errors may arise during installation or execution."
+    echo -e "Selected install type is: ${DEFAULT_INSTALL_TYPE}"
 
     read -r -e -p "Do you want to continue? [y/n]: " PROCEED
 

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -370,7 +370,6 @@ function check_os() {
     echo "FreeTAKServer has only been tested on ${GREEN}${OS_REQD} ${OS_VER_REQD}${NOFORMAT}."
     echo -e "This machine is currently running: ${YELLOW}${OS} ${VER}${NOFORMAT}"
     echo "Errors may arise during installation or execution."
-    echo -e "Selected install type is: ${DEFAULT_INSTALL_TYPE}"
 
     read -r -e -p "Do you want to continue? [y/n]: " PROCEED
 
@@ -391,6 +390,7 @@ function check_os() {
 
     echo -e "${GREEN}Success!${NOFORMAT}"
     echo -e "This machine is currently running: ${GREEN}${OS} ${VER}${NOFORMAT}"
+    echo -e "Selected install type is: ${DEFAULT_INSTALL_TYPE}"
 
   fi
 

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -390,7 +390,7 @@ function check_os() {
 
     echo -e "${GREEN}Success!${NOFORMAT}"
     echo -e "This machine is currently running: ${GREEN}${OS} ${VER}${NOFORMAT}"
-    echo -e "Selected install type is: ${DEFAULT_INSTALL_TYPE}"
+    echo -e "Selected install type is: ${GREEN}${DEFAULT_INSTALL_TYPE}"
 
   fi
 

--- a/scripts/easy_install.sh
+++ b/scripts/easy_install.sh
@@ -37,7 +37,7 @@ INSTALL_TYPE="${INSTALL_TYPE:-$DEFAULT_INSTALL_TYPE}"
 PY3_VER_LEGACY="3.8"
 PY3_VER_STABLE="3.11"
 
-STABLE_FTS_VERSION="2.0.69"
+STABLE_FTS_VERSION="2.0.66"
 LEGACY_FTS_VERSION="1.9.9.6"
 LATEST_FTS_VERSION=$(curl -s https://pypi.org/pypi/FreeTAKServer/json | python3 -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
 


### PR DESCRIPTION
Refactor ZT to install whatever the latest version of FTS is, according to the API return from: https://pypi.org/pypi/FreeTAKServer/json. Also, this may include some of the first raw python3 code in the ZT installer itself. May consider beginning to refactor much of ZT to Python rather than Bash. 